### PR TITLE
Especifica el relleno de la tortilla

### DIFF
--- a/comidas-semana22.md
+++ b/comidas-semana22.md
@@ -13,7 +13,7 @@
   - cena:tostas
 - sábado
   - comida:pescado
-  - cena:tortilla rellena
+  - cena:tortilla rellena (queso, jamón y espárragos)
 - domingo
   - comida:costilla
   - cena:gazpacho


### PR DESCRIPTION
No me parece bien que no queden claros los ingredientes del relleno. No sea que acabemos comiendo huevo con cabalacín